### PR TITLE
Prevent smooth-scroll errors for placeholder links

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,8 +697,13 @@
             // Smooth scrolling for navigation
             document.querySelectorAll('a[href^="#"]').forEach(anchor => {
                 anchor.addEventListener('click', function (e) {
+                    const href = this.getAttribute('href');
+                    // Ignore placeholder links that don't target an element
+                    if (href === '#') {
+                        return;
+                    }
                     e.preventDefault();
-                    const target = document.querySelector(this.getAttribute('href'));
+                    const target = document.querySelector(href);
                     if (target) {
                         target.scrollIntoView({
                             behavior: 'smooth',


### PR DESCRIPTION
## Summary
- avoid breaking smooth scroll when clicking placeholder links

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f9fe6b08832cb7ee8651811fbee2